### PR TITLE
feat: [FRONTEND] Implementation of basic CRUD for product management

### DIFF
--- a/frontend/src/api/productService.ts
+++ b/frontend/src/api/productService.ts
@@ -1,0 +1,49 @@
+import type { MakeRequestFunction } from "../types/api";
+import type { ProductProps, FormDataProps } from "../types/product";
+
+export const API_BASE_URL = "https://petshop-db4w.onrender.com/api/products";
+
+export class ProductService {
+  private makeRequest: MakeRequestFunction;
+
+  constructor(makeRequest: MakeRequestFunction) {
+    this.makeRequest = makeRequest;
+  }
+
+  async getAllProducts() {
+    return this.makeRequest<ProductProps[]>(API_BASE_URL);
+  }
+
+  async createProduct(productData: FormDataProps) {
+    const formattedData = {
+      ...productData,
+      price: parseFloat(productData.price),
+    };
+
+    return this.makeRequest<ProductProps>(API_BASE_URL, {
+      method: "POST",
+      body: JSON.stringify(formattedData),
+    });
+  }
+
+  async updateProduct(productId: number, productData: FormDataProps) {
+    const formattedData = {
+      ...productData,
+      price: parseFloat(productData.price),
+    };
+
+    return this.makeRequest<ProductProps>(`${API_BASE_URL}/${productId}`, {
+      method: "PUT",
+      body: JSON.stringify(formattedData),
+    });
+  }
+
+  async deleteProduct(productId: number) {
+    return this.makeRequest<void>(`${API_BASE_URL}/${productId}`, {
+      method: "DELETE",
+    });
+  }
+}
+
+export const createProductService = (makeRequest: MakeRequestFunction) =>
+  new ProductService(makeRequest);

--- a/frontend/src/components/modal/DeleteProductConfirmationModal.tsx
+++ b/frontend/src/components/modal/DeleteProductConfirmationModal.tsx
@@ -1,0 +1,55 @@
+import { X } from "lucide-react";
+import type { DeleteProductConfirmationModalProps } from "../../types/product";
+
+export function DeleteProductConfirmationModal({
+  showDeleteModal,
+  actionLoading,
+  closeDeleteModal,
+  handleDelete,
+}: DeleteProductConfirmationModalProps) {
+  if (!showDeleteModal) {
+    return null;
+  }
+
+  return (
+    <article className="fixed inset-0 bg-black/60 bg-opacity-50 flex items-center justify-center z-50">
+      <div className="bg-gray-800 rounded-lg p-6 w-full max-w-md mx-4 text-center">
+        <header className="flex justify-end mb-4">
+          <button
+            type="button"
+            onClick={closeDeleteModal}
+            className="p-2 bg-gray-600 hover:bg-gray-700 text-white rounded-lg transition-colors"
+          >
+            <X size={18} />
+          </button>
+        </header>
+        <main>
+          <h2 className="text-xl font-bold text-white mb-4">
+            Confirmar eliminación
+          </h2>
+          <p className="text-gray-300 mb-6">
+            ¿Estás seguro de que deseas eliminar este producto? Esta acción no
+            se puede deshacer.
+          </p>
+        </main>
+        <footer className="flex justify-center space-x-3 mt-6">
+          <button
+            type="button"
+            onClick={closeDeleteModal}
+            className="px-4 py-2 bg-gray-600 hover:bg-gray-700 text-white rounded-lg transition-colors"
+          >
+            Cancelar
+          </button>
+          <button
+            type="button"
+            onClick={handleDelete}
+            disabled={actionLoading}
+            className="px-4 py-2 bg-red-600 hover:bg-red-700 text-white rounded-lg transition-colors disabled:opacity-50"
+          >
+            {actionLoading ? "Eliminando..." : "Eliminar"}
+          </button>
+        </footer>
+      </div>
+    </article>
+  );
+}

--- a/frontend/src/components/modal/ProductModal.tsx
+++ b/frontend/src/components/modal/ProductModal.tsx
@@ -1,0 +1,158 @@
+import { type FormEvent } from "react";
+import { X } from "lucide-react";
+import type { ProductModalProps } from "../../types/product";
+
+export function ProductModal({
+  showModal,
+  editingProduct,
+  formData,
+  actionLoading,
+  closeModal,
+  handleSubmit,
+  handleInputChange,
+}: ProductModalProps) {
+  const onSubmit = async (e: FormEvent) => {
+    e.preventDefault();
+    await handleSubmit();
+  };
+
+  if (!showModal) {
+    return null;
+  }
+
+  return (
+    <article className="fixed inset-0 bg-black/60 bg-opacity-50 flex items-center justify-center z-50">
+      <div className="bg-gray-800 rounded-lg py-4 p-6 w-full max-w-md mx-4">
+        <header className="flex justify-between items-center mb-4">
+          <h2 className="text-xl font-bold text-white">
+            {editingProduct ? "Editar Producto" : "Agregar Producto"}
+          </h2>
+          <button
+            type="button"
+            onClick={closeModal}
+            className="p-2 bg-gray-600 hover:bg-gray-700 text-white rounded-lg transition-colors"
+          >
+            <X size={18} />
+          </button>
+        </header>
+
+        <form onSubmit={onSubmit}>
+          <main className="space-y-2">
+            <div>
+              <label
+                htmlFor="title"
+                className="block text-white text-sm font-medium mb-2"
+              >
+                Nombre
+              </label>
+              <input
+                id="title"
+                type="text"
+                name="title"
+                value={formData.title}
+                onChange={handleInputChange}
+                className="w-full px-3 py-2 bg-gray-700 text-white rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500"
+                required
+              />
+            </div>
+            <div>
+              <label
+                htmlFor="price"
+                className="block text-white text-sm font-medium mb-2"
+              >
+                Precio
+              </label>
+              <input
+                id="price"
+                type="number"
+                name="price"
+                value={formData.price}
+                onChange={handleInputChange}
+                step="0.01"
+                className="w-full px-3 py-2 bg-gray-700 text-white rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500"
+                required
+              />
+            </div>
+            <div>
+              <label
+                htmlFor="category"
+                className="block text-white text-sm font-medium mb-2"
+              >
+                Categoría
+              </label>
+              <input
+                id="category"
+                type="text"
+                name="category"
+                value={formData.category}
+                onChange={handleInputChange}
+                className="w-full px-3 py-2 bg-gray-700 text-white rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500"
+                required
+              />
+            </div>
+
+            <div>
+              <label
+                htmlFor="image"
+                className="block text-white text-sm font-medium mb-2"
+              >
+                URL de la imagen
+              </label>
+              <input
+                id="image"
+                type="text"
+                name="image"
+                value={formData.image}
+                onChange={handleInputChange}
+                className="w-full px-3 py-2 bg-gray-700 text-white rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500"
+              />
+            </div>
+
+            <div>
+              <label
+                htmlFor="description"
+                className="block text-white text-sm font-medium mb-2"
+              >
+                Descripción
+                <span className="text-gray-400 text-xs ml-2">
+                  ({formData.description.length}/145)
+                </span>
+              </label>
+              <textarea
+                id="description"
+                name="description"
+                value={formData.description}
+                onChange={handleInputChange}
+                rows={2}
+                maxLength={145}
+                className="w-full px-3 py-2 bg-gray-700 text-white rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500"
+                placeholder="Descripción del producto (máximo 145 caracteres)"
+              />
+            </div>
+          </main>
+
+          <footer className="flex justify-end space-x-3 mt-6">
+            <button
+              type="button"
+              onClick={closeModal}
+              className="px-4 py-2 bg-gray-600 hover:bg-gray-700 text-white rounded-lg transition-colors"
+            >
+              Cancelar
+            </button>
+            <button
+              type="submit"
+              disabled={actionLoading}
+              className="px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded-lg transition-colors disabled:opacity-50"
+            >
+              {actionLoading
+                ? "Guardando..."
+                : editingProduct
+                ? "Actualizar"
+                : "Crear"}
+            </button>
+          </footer>
+        </form>
+      </div>
+    </article>
+  );
+}

--- a/frontend/src/components/ui/navbar/NavBar.tsx
+++ b/frontend/src/components/ui/navbar/NavBar.tsx
@@ -8,12 +8,11 @@ import {
 
 import { Link } from "react-router-dom";
 import useAuthToken from "../../../hooks/useAuthToken";
-import { CircleUserRound } from 'lucide-react';
-
+import { CircleUserRound } from "lucide-react";
 
 const NavBar = () => {
   const token = useAuthToken();
-  const userName =  localStorage.getItem("username");
+  const userName = localStorage.getItem("username");
 
   return (
     <nav className="flex bg-slate-900 text-white justify-between rounded-2xl p-2 text-2xl">
@@ -27,17 +26,30 @@ const NavBar = () => {
           </NavigationMenuItem>
         </NavigationMenuList>
       </NavigationMenu>
-    
 
       {token ? (
-        <div className="flex items-center">
-        <div className="flex ">
-          <span><CircleUserRound /></span>
-          <p className="ml-2 text-sm">Welcome, {userName}</p>
+        <div className="flex items-center gap-2">
+          <div className="flex ">
+            <span>
+              <CircleUserRound />
+            </span>
+            <p className="ml-2 text-sm">Welcome, {userName}</p>
+          </div>
+
+          {/*Products link */}
+          <NavigationMenu>
+            <NavigationMenuList>
+              <NavigationMenuItem>
+                <NavigationMenuLink asChild>
+                  <Link to="/products">Products</Link>
+                </NavigationMenuLink>
+              </NavigationMenuItem>
+            </NavigationMenuList>
+          </NavigationMenu>
+          <span>|</span>
+
+          <Logout />
         </div>
-        <Logout />
-        </div>
-        
       ) : (
         <div className="flex">
           {/*login link */}

--- a/frontend/src/hooks/useAuthApi.ts
+++ b/frontend/src/hooks/useAuthApi.ts
@@ -1,0 +1,61 @@
+import { useState } from "react";
+
+export function useAuthApi(token: string | null) {
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const makeRequest = async <T = unknown>(
+    url: string,
+    options: RequestInit = {}
+  ): Promise<T> => {
+    if (!token) {
+      throw new Error("No hay token de autenticación");
+    }
+
+    setLoading(true);
+    setError(null);
+
+    try {
+      const res = await fetch(url, {
+        ...options,
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${token}`,
+          ...options.headers,
+        },
+      });
+
+      if (!res.ok) {
+        let errorMessage = `Error ${res.status}`;
+
+        try {
+          const errorData = await res.json();
+          errorMessage = errorData.message || errorData.error || errorMessage;
+        } catch {
+          errorMessage = res.statusText || errorMessage;
+        }
+
+        throw new Error(errorMessage);
+      }
+
+      if (options.method === "DELETE") {
+        const text = await res.text();
+        return (text ? JSON.parse(text) : {}) as T;
+      }
+
+      const json = await res.json();
+      return json;
+    } catch (err: unknown) {
+      if (err instanceof Error) {
+        setError(err.message);
+      } else {
+        setError("Error desconocido");
+      }
+      throw err;
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return { makeRequest, loading, error };
+}

--- a/frontend/src/hooks/useAuthQuery.ts
+++ b/frontend/src/hooks/useAuthQuery.ts
@@ -1,0 +1,49 @@
+import { useEffect, useState } from "react";
+
+export function useAuthQuery<T = unknown>(url: string, token?: string | null) {
+  const [data, setData] = useState<T | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!token) {
+      setLoading(false);
+      setError("No hay token de autenticación");
+      return;
+    }
+
+    const fetchData = async () => {
+      try {
+        setLoading(true);
+        setError(null);
+
+        const res = await fetch(url, {
+          method: "GET",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${token}`,
+          },
+        });
+
+        if (!res.ok) {
+          throw new Error(`Error ${res.status}: ${res.statusText}`);
+        }
+
+        const json = await res.json();
+        setData(json);
+      } catch (err: unknown) {
+        if (err instanceof Error) {
+          setError(err.message);
+        } else {
+          setError("Error desconocido");
+        }
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchData();
+  }, [url, token]);
+
+  return { data, loading, error };
+}

--- a/frontend/src/hooks/useProducts.ts
+++ b/frontend/src/hooks/useProducts.ts
@@ -1,0 +1,154 @@
+import { useState, useEffect } from "react";
+import { useAuthQuery } from "./useAuthQuery";
+import { useAuthApi } from "./useAuthApi";
+import { API_BASE_URL, createProductService } from "../api/productService";
+import type { ProductProps, FormDataProps } from "../types/product";
+
+export const useProducts = (token: string | null) => {
+  const [productList, setProductList] = useState<ProductProps[]>([]);
+  const [showModal, setShowModal] = useState<boolean>(false);
+  const [editingProduct, setEditingProduct] = useState<ProductProps | null>(
+    null
+  );
+  const [formData, setFormData] = useState<FormDataProps>({
+    title: "",
+    price: "",
+    description: "",
+    category: "",
+    image: "",
+  });
+  const [showDeleteModal, setShowDeleteModal] = useState<boolean>(false);
+  const [productToDelete, setProductToDelete] = useState<number | null>(null);
+  const {
+    data: products,
+    loading: fetchLoading,
+    error: fetchError,
+  } = useAuthQuery<ProductProps[]>(API_BASE_URL, token);
+  const {
+    makeRequest,
+    loading: actionLoading,
+    error: actionError,
+  } = useAuthApi(token);
+
+  const productService = createProductService(makeRequest);
+
+  useEffect(() => {
+    if (products) {
+      setProductList(products);
+    }
+  }, [products]);
+
+  const openModal = (product: ProductProps | null = null) => {
+    if (product) {
+      setEditingProduct(product);
+      setFormData({
+        title: product.title,
+        price: product.price.toString(),
+        description: product.description,
+        category: product.category,
+        image: product.image,
+      });
+    } else {
+      setEditingProduct(null);
+      setFormData({
+        title: "",
+        price: "",
+        description: "",
+        category: "",
+        image: "",
+      });
+    }
+    setShowModal(true);
+  };
+
+  const closeModal = () => {
+    setShowModal(false);
+    setEditingProduct(null);
+    setFormData({
+      title: "",
+      price: "",
+      description: "",
+      category: "",
+      image: "",
+    });
+  };
+
+  const handleSubmit = async (): Promise<boolean> => {
+    try {
+      if (editingProduct) {
+        const updatedProduct = await productService.updateProduct(
+          editingProduct.id,
+          formData
+        );
+        setProductList((prev) =>
+          prev.map((p) => (p.id === editingProduct.id ? updatedProduct : p))
+        );
+      } else {
+        const newProduct = await productService.createProduct(formData);
+        setProductList((prev) => [...prev, newProduct]);
+      }
+
+      closeModal();
+      return true;
+    } catch (error) {
+      console.error("Error al guardar producto:", error);
+      return false;
+    }
+  };
+
+  const handleInputChange = (
+    e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
+  ) => {
+    const { name, value } = e.target;
+    setFormData((prev) => ({
+      ...prev,
+      [name]: value,
+    }));
+  };
+
+  const openDeleteModal = (productId: number) => {
+    setProductToDelete(productId);
+    setShowDeleteModal(true);
+  };
+
+  const closeDeleteModal = () => {
+    setProductToDelete(null);
+    setShowDeleteModal(false);
+  };
+
+  const handleDelete = async (): Promise<boolean> => {
+    if (!productToDelete) {
+      return false;
+    }
+
+    try {
+      await productService.deleteProduct(productToDelete);
+      setProductList((prev) => prev.filter((p) => p.id !== productToDelete));
+      closeDeleteModal();
+      return true;
+    } catch (error) {
+      console.error("Error al eliminar producto:", error);
+      return false;
+    }
+  };
+
+  return {
+    productList,
+    showModal,
+    editingProduct,
+    formData,
+    fetchLoading,
+    fetchError,
+    actionLoading,
+    actionError,
+    openModal,
+    closeModal,
+    handleSubmit,
+    handleInputChange,
+    showDeleteModal,
+    productToDelete,
+    openDeleteModal,
+    closeDeleteModal,
+    handleDelete,
+  };
+};

--- a/frontend/src/pages/products/Products.tsx
+++ b/frontend/src/pages/products/Products.tsx
@@ -1,0 +1,149 @@
+import useAuthToken from "../../hooks/useAuthToken";
+import { useProducts } from "../../hooks/useProducts";
+import { ProductModal } from "../../components/modal/ProductModal";
+import { DeleteProductConfirmationModal } from "../../components/modal/DeleteProductConfirmationModal";
+
+function Products() {
+  const token = useAuthToken();
+  const {
+    productList,
+    showModal,
+    editingProduct,
+    formData,
+    fetchLoading,
+    fetchError,
+    actionLoading,
+    actionError,
+    showDeleteModal,
+    openModal,
+    closeModal,
+    handleSubmit,
+    openDeleteModal,
+    closeDeleteModal,
+    handleDelete,
+    handleInputChange,
+  } = useProducts(token);
+
+  if (fetchLoading) {
+    return <p className="text-white p-4">Cargando productos...</p>;
+  }
+
+  if (fetchError) {
+    return <p className="text-red-500 p-4">Error: {fetchError}</p>;
+  }
+
+  return (
+    <section className="p-6 bg-gray-900 min-h-screen">
+      <article className="max-w-6xl mx-auto">
+        <header className="flex justify-between items-center mb-6">
+          <h1 className="text-xl md:text-3xl font-bold text-white">
+            Gestión de Productos
+          </h1>
+          <button
+            onClick={() => openModal()}
+            className="bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded-lg transition-colors"
+          >
+            Agregar Producto
+          </button>
+        </header>
+
+        {actionError && (
+          <article className="bg-red-500 text-white p-3 rounded-lg mb-4">
+            {actionError}
+          </article>
+        )}
+
+        <main className="bg-gray-800 rounded-lg overflow-hidden shadow-lg overflow-x-auto">
+          <table className="w-full min-w-lg">
+            <thead className="bg-gray-700">
+              <tr>
+                <th className="px-6 py-3 text-left text-white font-semibold">
+                  ID
+                </th>
+                <th className="px-6 py-3 text-left text-white font-semibold">
+                  Nombre
+                </th>
+                <th className="px-6 py-3 text-left text-white font-semibold">
+                  Precio
+                </th>
+                <th className="px-6 py-3 text-left text-white font-semibold">
+                  Categoría
+                </th>
+                <th className="px-6 py-3 text-left text-white font-semibold">
+                  Acciones
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              {productList && productList.length > 0 ? (
+                productList.map((product) => (
+                  <tr
+                    key={product.id}
+                    className="border-b border-gray-700 hover:bg-gray-750"
+                  >
+                    <td className="px-6 py-4 text-gray-300">{product.id}</td>
+                    <td className="px-6 py-4 text-white font-medium">
+                      {product.title}
+                    </td>
+                    <td className="px-6 py-4 text-green-400">
+                      ${product.price}
+                    </td>
+                    <td className="px-6 py-4 text-gray-300">
+                      {product.category}
+                    </td>
+                    <td className="px-6 py-4">
+                      <div className="flex space-x-2">
+                        <button
+                          onClick={() => openModal(product)}
+                          className="bg-yellow-600 hover:bg-yellow-700 text-white px-3 py-1 rounded text-sm transition-colors"
+                          disabled={actionLoading}
+                        >
+                          Editar
+                        </button>
+                        <button
+                          onClick={() => openDeleteModal(product.id)}
+                          className="bg-red-600 hover:bg-red-700 text-white px-3 py-1 rounded text-sm transition-colors"
+                          disabled={actionLoading}
+                        >
+                          Eliminar
+                        </button>
+                      </div>
+                    </td>
+                  </tr>
+                ))
+              ) : (
+                <tr>
+                  <td
+                    colSpan={5}
+                    className="px-6 py-8 text-center text-gray-400"
+                  >
+                    No hay productos disponibles
+                  </td>
+                </tr>
+              )}
+            </tbody>
+          </table>
+        </main>
+      </article>
+
+      <ProductModal
+        showModal={showModal}
+        editingProduct={editingProduct}
+        formData={formData}
+        actionLoading={actionLoading}
+        closeModal={closeModal}
+        handleSubmit={handleSubmit}
+        handleInputChange={handleInputChange}
+      />
+
+      <DeleteProductConfirmationModal
+        showDeleteModal={showDeleteModal}
+        actionLoading={actionLoading}
+        closeDeleteModal={closeDeleteModal}
+        handleDelete={handleDelete}
+      />
+    </section>
+  );
+}
+
+export default Products;

--- a/frontend/src/routing/router.tsx
+++ b/frontend/src/routing/router.tsx
@@ -6,26 +6,24 @@ import NotFoundPage from "../pages/NotFoundPage";
 import Layout from "../components/Layout";
 import Dashboard from "../pages/Dashboard";
 import { PrivateRoute } from "../components/features/PrivateRoute";
+import Products from "../pages/products/Products";
 
 const router = createBrowserRouter([
-    {
-      path: "/",
-      element: <Layout />,
-      children: [
-        { index: true, element: <Home /> },
-        { path: "login", element: <Login /> },
-        { path: "register", element: <Register /> },
-        { 
-          element: <PrivateRoute />,
-          children: [
-            { path: "dashboard", element: <Dashboard />}
-          ]
-        },
-        { path: "*", element: <NotFoundPage /> }
-      ]
-    }
-  ]);
-  
+  {
+    path: "/",
+    element: <Layout />,
+    children: [
+      { index: true, element: <Home /> },
+      { path: "login", element: <Login /> },
+      { path: "register", element: <Register /> },
+      { path: "products", element: <Products /> },
+      {
+        element: <PrivateRoute />,
+        children: [{ path: "dashboard", element: <Dashboard /> }],
+      },
+      { path: "*", element: <NotFoundPage /> },
+    ],
+  },
+]);
 
-
-export default router
+export default router;

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -1,0 +1,4 @@
+export type MakeRequestFunction = <T = unknown>(
+  url: string,
+  options?: RequestInit
+) => Promise<T>;

--- a/frontend/src/types/product.ts
+++ b/frontend/src/types/product.ts
@@ -22,3 +22,10 @@ export interface ProductModalProps {
     e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
   ) => void;
 }
+
+export interface DeleteProductConfirmationModalProps {
+  showDeleteModal: boolean;
+  actionLoading: boolean;
+  closeDeleteModal: () => void;
+  handleDelete: () => Promise<boolean>;
+}

--- a/frontend/src/types/product.ts
+++ b/frontend/src/types/product.ts
@@ -1,0 +1,24 @@
+export interface ProductProps {
+  id: number;
+  title: string;
+  price: number;
+  description: string;
+  category: string;
+  image: string;
+}
+
+export type FormDataProps = Omit<ProductProps, "id" | "price"> & {
+  price: string;
+};
+
+export interface ProductModalProps {
+  showModal: boolean;
+  editingProduct: ProductProps | null;
+  formData: FormDataProps;
+  actionLoading: boolean;
+  closeModal: () => void;
+  handleSubmit: () => Promise<boolean>;
+  handleInputChange: (
+    e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
+  ) => void;
+}


### PR DESCRIPTION
### Description

This PR introduces full functionality for product management on the frontend.

A table displaying products retrieved from the API has been implemented, and full CRUD functionality has been added for interacting with them.

### Changes Made

- **`Products` component**: The main view displaying the list of products in a table has been created.
- **`useProducts` hook**: A custom hook has been developed to handle CRUD state logic (loading, errors, forms, etc.), keeping the main component clean and presentation-focused.
- **Modals**: The create/edit modals (`ProductModal`) and delete confirmation modals (`DeleteConfirmationModal`) have been separated into dedicated components to improve modularity and code reuse.
- **API Integration**: `useAuthApi` and `productService` have been configured to handle API operations, including fixing common errors such as JSON serialization and 204 delete responses.
- **Routes**: The corresponding route has been added for displaying the product page.

### Added Features

- **View Products**: Displays a list of products.
- **Create Product**: An "Add Product" button that opens a modal with a form.
- **Edit Product**: An "Edit" button on each row that opens a modal with pre-populated product data.
- **Delete Product**: A "Delete" button with a visually appealing confirmation modal that performs a physical deletion of the record.

### Next Steps and Important Notes

- The current delete function is a **hard delete**. As discussed, the plan is to migrate to logical deletion in the near future. An issue (#94) has been created to track this improvement.
- Display the paginated product list.